### PR TITLE
Add 'install' target for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,28 @@
-.PHONY: book clean spotless all serve check pdf
+.PHONY: book clean spotless all serve check pdf pip-install install
 
 all: book
 
-book:
+pip-install:
+	python -m pip install -r requirements.txt
+
+install: pip-install
+	ipython kernel install --name "dstbook" --user
+
+book: install
 	jupyter-book build ./
 
-clean:
+clean: install
 	jupyter-book clean ./
 
-spotless:
+spotless: install
 	jupyter-book clean ./ --all
 
 serve: book
 	python -m http.server --directory _build/html/
 
-check:
+check: install
 	jupyter-book build ./ --builder linkcheck
 
-pdf:
+pdf: install
+	@command -v latexmk >/dev/null 2>&1 || { echo >&2 "Building the PDF requires latexmk but it's not installed.  Aborting."; exit 1; }
 	jupyter-book build ./ --builder pdflatex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ipython>=8.4.0
+ipykernel>=6.13.1
+jupyter-book>=0.13.0
+sphinx_exercise>=0.4.1
+sphinx_proof==0.1.3
+sphinxcontrib-svg2pdfconverter>=1.1.1


### PR DESCRIPTION
To facilitate people (like me, going on a 17 hour plane trip) who want an offline version.

This adds an "install" step, which installs the required python packages and creates the appropriate ipython kernel.

It should now be possible in a fresh virtual environment to run:

```
make book
```

And have it "just work"