### PR TITLE
spelling

### DIFF
--- a/content/appendixA/ModularArithmetic.ipynb
+++ b/content/appendixA/ModularArithmetic.ipynb
@@ -23,7 +23,7 @@
     "# Modular arithmetic\n",
     "\n",
     "Another common feature of mathematics of signal processing is the need to deal with repeating sequences and periodicity.\n",
-    "We use real numbers to model continuously repeating processes (like a point traveling continuously around a circle), but we also occasionally have **discrete** repeating processes, like the hours on a clock: 12:00, 1:00, 2:00, \\dots, 11:00.\n",
+    "We use real numbers to model continuously repeating processes (like a point traveling continuously around a circle), but we also occasionally have **discrete** repeating processes, like the hours on a clock: 12:00, 1:00, 2:00, $\\dots$, 11:00.\n",
     "**Modular arithmetic** is the math of discrete repetition.\n",
     "\n",
     "For a positive integer $N > 1$ (the *modulus*), we define for any integer $q \\in \\mathbb{Z}$\n",

--- a/content/ch02-sampling/Quantization.ipynb
+++ b/content/ch02-sampling/Quantization.ipynb
@@ -1495,7 +1495,7 @@
     "By now, we've seen how quantization works, what it looks like visually, and how it sounds.\n",
     "But how do we use this information practically?\n",
     "\n",
-    "16-bit quantization (65536 distinct values) is the standard for compct disc-quality audio, and it suffices for many practical applications.\n",
+    "16-bit quantization (65536 distinct values) is the standard for compact disc-quality audio, and it suffices for many practical applications.\n",
     "24-bit quantization is also common (16777216 distinct values), especially in music production or other applications with high-fidelity requirements."
    ]
   },


### PR DESCRIPTION
fix for: for compct disc-quality audio and hours on a clock: 12:00, 1:00, 2:00, $\\dots$, 11:00.\n"